### PR TITLE
Add encoder/decoder for GetItem Handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Abstract away dynamodb dependency. [#35](https://github.com/xmidt-org/argus/pull/35)
+- Add unit tests for new dynamodb abstraction changes. [#39](https://github.com/xmidt-org/argus/pull/39)
+- Add encoders/decoders for GetItem Handler. [#44](https://github.com/xmidt-org/argus/pull/44)
+
 
 ## [v0.3.5]
 ### Changed

--- a/store/endpoint.go
+++ b/store/endpoint.go
@@ -22,9 +22,10 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"net/http"
+
 	"github.com/go-kit/kit/endpoint"
 	"github.com/xmidt-org/argus/model"
-	"net/http"
 )
 
 type KeyNotFoundError struct {
@@ -103,6 +104,21 @@ func NewSetEndpoint(s S) endpoint.Endpoint {
 		}
 		err := s.Push(kv.Key, kv.OwnableItem)
 		return kv.Key, err
+	}
+}
+
+func newGetItemEndpoint(s S) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		itemRequest := request.(*getItemRequest)
+		itemResponse, err := s.Get(itemRequest.key)
+		if err != nil {
+			return nil, err
+		}
+		if itemRequest.owner == "" || itemRequest.owner == itemResponse.Owner {
+			return itemResponse, nil
+		}
+
+		return nil, &KeyNotFoundError{Key: itemRequest.key}
 	}
 }
 

--- a/store/errors.go
+++ b/store/errors.go
@@ -1,0 +1,15 @@
+package store
+
+import "net/http"
+
+type BadRequestErr struct {
+	Message string
+}
+
+func (bre BadRequestErr) Error() string {
+	return bre.Message
+}
+
+func (bre BadRequestErr) StatusCode() int {
+	return http.StatusBadRequest
+}

--- a/store/handler.go
+++ b/store/handler.go
@@ -60,6 +60,15 @@ func NewHandler(e endpoint.Endpoint, itemTTL ItemTTL) Handler {
 	)
 }
 
+func newGetItemHandler(s S) Handler {
+	return kithttp.NewServer(
+		newGetItemEndpoint(s),
+		decodeGetItemRequest,
+		encodeGetItemResponse,
+		kithttp.ServerErrorEncoder(encodeError),
+	)
+}
+
 type requestHandler struct {
 	ItemTTL ItemTTL
 }

--- a/store/transport.go
+++ b/store/transport.go
@@ -22,8 +22,10 @@ const (
 	idVarMissingMsg     = "{id} URL path parameter missing"
 )
 
+// Request and Response Headers
 const (
-	ItemOwnerHeaderKey = "X-Xmidt-Owner"
+	ItemOwnerHeaderKey  = "X-Xmidt-Owner"
+	XmidtErrorHeaderKey = "X-Xmidt-Error"
 )
 
 // TODO: since GET and DELETE are so similar, we could make them share at least the
@@ -77,8 +79,7 @@ func encodeGetItemResponse(ctx context.Context, rw http.ResponseWriter, response
 }
 
 func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.Header().Set("X-Xmidt-Error", err.Error())
+	w.Header().Set(XmidtErrorHeaderKey, err.Error())
 	if headerer, ok := err.(kithttp.Headerer); ok {
 		for k, values := range headerer.Headers() {
 			for _, v := range values {

--- a/store/transport.go
+++ b/store/transport.go
@@ -28,6 +28,8 @@ const (
 	XmidtErrorHeaderKey = "X-Xmidt-Error"
 )
 
+var ErrCastingEncodeGetItemResponse = errors.New("casting error in encodeGetItemResponse")
+
 // TODO: since GET and DELETE are so similar, we could make them share at least the
 // decoders
 type getItemRequest struct {
@@ -58,9 +60,9 @@ func decodeGetItemRequest(ctx context.Context, r *http.Request) (interface{}, er
 }
 
 func encodeGetItemResponse(ctx context.Context, rw http.ResponseWriter, response interface{}) error {
-	item, ok := response.(OwnableItem)
+	item, ok := response.(*OwnableItem)
 	if !ok {
-		return errors.New("casting error in encodeGetItemResponse")
+		return ErrCastingEncodeGetItemResponse
 	}
 
 	if item.TTL <= 0 {

--- a/store/transport.go
+++ b/store/transport.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+	"github.com/xmidt-org/argus/model"
+)
+
+// request URL path keys
+const (
+	bucketVarKey = "bucket"
+	idVarKey     = "id"
+)
+
+const (
+	bucketVarMissingMsg = "{bucket} URL path parameter missing"
+	idVarMissingMsg     = "{id} URL path parameter missing"
+)
+
+const (
+	ItemOwnerHeaderKey = "X-Xmidt-Owner"
+)
+
+// TODO: since GET and DELETE are so similar, we could make them share at least the
+// decoders
+type getItemRequest struct {
+	key   model.Key
+	owner string
+}
+
+func decodeGetItemRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+	bucket, ok := vars[bucketVarKey]
+	if !ok {
+		return nil, &BadRequestErr{Message: bucketVarMissingMsg}
+	}
+
+	id, ok := vars[idVarKey]
+
+	if !ok {
+		return nil, &BadRequestErr{Message: idVarMissingMsg}
+	}
+
+	return &getItemRequest{
+		key: model.Key{
+			Bucket: bucket,
+			ID:     id,
+		},
+		owner: r.Header.Get(ItemOwnerHeaderKey),
+	}, nil
+}
+
+func encodeGetItemResponse(ctx context.Context, rw http.ResponseWriter, response interface{}) error {
+	item, ok := response.(OwnableItem)
+	if !ok {
+		return errors.New("casting error in encodeGetItemResponse")
+	}
+
+	if item.TTL <= 0 {
+		rw.WriteHeader(http.StatusNotFound)
+		return nil
+	}
+
+	data, err := json.Marshal(&item.Item)
+	if err != nil {
+		return err
+	}
+
+	rw.Header().Add("Content-Type", "application/json")
+	rw.Write(data)
+	return nil
+}
+
+func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Xmidt-Error", err.Error())
+	if headerer, ok := err.(kithttp.Headerer); ok {
+		for k, values := range headerer.Headers() {
+			for _, v := range values {
+				w.Header().Add(k, v)
+			}
+		}
+	}
+	code := http.StatusInternalServerError
+	if sc, ok := err.(kithttp.StatusCoder); ok {
+		code = sc.StatusCode()
+	}
+	w.WriteHeader(code)
+}

--- a/store/transport_test.go
+++ b/store/transport_test.go
@@ -1,0 +1,90 @@
+package store
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/xmidt-org/argus/model"
+)
+
+func TestDecodeGetItemRequest(t *testing.T) {
+	testCases := []struct {
+		Name                   string
+		URLVars                map[string]string
+		Headers                map[string][]string
+		ExpectedDecodedRequest interface{}
+		ExpectedErr            error
+	}{
+		{
+			Name: "Missing id",
+			URLVars: map[string]string{
+				"bucket": "california",
+			},
+			ExpectedErr: &BadRequestErr{Message: idVarMissingMsg},
+		},
+		{
+			Name: "Missing bucket",
+			URLVars: map[string]string{
+				"id": "san francisco",
+			},
+			ExpectedErr: &BadRequestErr{Message: bucketVarMissingMsg},
+		},
+		{
+			Name: "Happy path - No owner",
+			URLVars: map[string]string{
+				"bucket": "california",
+				"id":     "san francisco",
+			},
+			ExpectedDecodedRequest: &getItemRequest{
+				key: model.Key{
+					Bucket: "california",
+					ID:     "san francisco",
+				},
+			},
+		},
+		{
+			Name: "Happy path",
+			URLVars: map[string]string{
+				"bucket": "california",
+				"id":     "san francisco",
+			},
+
+			ExpectedDecodedRequest: &getItemRequest{
+				key: model.Key{
+					Bucket: "california",
+					ID:     "san francisco",
+				},
+				owner: "SF Giants",
+			},
+			Headers: map[string][]string{
+				ItemOwnerHeaderKey: []string{"SF Giants"},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			assert := assert.New(t)
+			r := httptest.NewRequest(http.MethodGet, "http://localhost/test", nil)
+			transferHeaders(testCase.Headers, r)
+
+			r = mux.SetURLVars(r, testCase.URLVars)
+			decodedRequest, err := decodeGetItemRequest(context.Background(), r)
+
+			assert.Equal(testCase.ExpectedDecodedRequest, decodedRequest)
+			assert.Equal(testCase.ExpectedErr, err)
+		})
+	}
+}
+
+func transferHeaders(headers map[string][]string, r *http.Request) {
+	for k, values := range headers {
+		for _, value := range values {
+			r.Header.Add(k, value)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds the encoders and decoders for the GetItem Handler. I left out the unit tests for encodeError for now as I plan to tackle that in a subsequent PR. 

Once all the Handlers are created, I will create a separate PR that does the switch to using them in the store provide function.