### PR TITLE
update code to match latest API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v0.3.8]
+- Update code to abide by latest API spec in the main repo readme. [#71](https://github.com/xmidt-org/argus/pull/71)
+
 ## [v0.3.7]
 ### Changed
 - Changes the PUT creation route to a POST. [#68](https://github.com/xmidt-org/argus/pull/68)
@@ -82,7 +85,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [v0.1.0] Tue May 07 2020 Jack Murdock - 0.1.0
 - initial creation
 
-[Unreleased]: https://github.com/xmidt-org/argus/compare/v0.3.7...HEAD
+[Unreleased]: https://github.com/xmidt-org/argus/compare/v0.3.8...HEAD
+[v0.3.8]: https://github.com/xmidt-org/argus/compare/v0.3.7...v0.3.8
 [v0.3.7]: https://github.com/xmidt-org/argus/compare/v0.3.6...v0.3.7
 [v0.3.6]: https://github.com/xmidt-org/argus/compare/v0.3.5...v0.3.6
 [v0.3.5]: https://github.com/xmidt-org/argus/compare/v0.3.4...v0.3.5

--- a/argus.yaml
+++ b/argus.yaml
@@ -84,7 +84,7 @@ servers:
 dynamo:
   # endpoint is used to set a custom aws endpoint.
   # (Optional)
-  endpoint: "http://localhost:8042"
+  endpoint: "http://localhost:8000"
 
   # table is the name of the table that is already configured with bucket and id as the key.
   table: "gifnoc"
@@ -104,11 +104,6 @@ dynamo:
 
 # itemTTL configures the default time based ttls for each item.
 itemTTL:
-  # defaultTTL is used if not ttl is provided via the api.
-  # refer to https://golang.org/pkg/time/#ParseDuration for valid strings.
-  # (Optional) default: 5m
-  defaultTTL: "5m"
-
   # maxTTL is limit the maxTTL provided via the api.
   # refer to https://golang.org/pkg/time/#ParseDuration for valid strings.
   # (Optional) default: 1y

--- a/argus.yaml
+++ b/argus.yaml
@@ -117,6 +117,18 @@ itemTTL:
 # WARNING! Be sure to remove this from your production config
 authHeader: ["dXNlcjpwYXNz"]
 
+# request is a config section related to operation authorization
+# and request validation.
+request:
+  authorization:
+    # adminToken serves as a master key which allows performing operations on any 
+    # item regardless of their ownership status.  
+    adminToken: "Hzu1WpIe7S8G" 
+
+  validation:
+    # maxTTL specifies the cap for the TTL of items when values are specified.
+    maxTTL: "24h"
+
 # jwtValidator provides Bearer auth configuration
 jwtValidator:
   keys:
@@ -124,6 +136,7 @@ jwtValidator:
       uri: "http://sample-jwt-validator-uri/{keyId}"
     purpose: 0
     updateInterval: 604800000000000
+
 # capabilityCheck provides the details needed for checking an incoming JWT's
 # capabilities.  If the type of check isn't provided, no checking is done.  The
 # type can be "monitor" or "enforce".  If it is empty or a different value, no

--- a/chrysom/client.go
+++ b/chrysom/client.go
@@ -39,10 +39,10 @@ import (
 // PushItem operation.
 type PushResult string
 
-// Types of set item successful results.
+// Types of pushItem successful results.
 const (
-	CreatedSetResult PushResult = "created"
-	UpdatedSetResult PushResult = "ok"
+	CreatedPushResult PushResult = "created"
+	UpdatedPushResult PushResult = "ok"
 )
 
 type ClientConfig struct {
@@ -134,6 +134,10 @@ func validateConfig(config *ClientConfig) error {
 	}
 	if config.MetricsProvider == nil {
 		return errors.New("a metrics provider is required")
+	}
+
+	if config.PullInterval == 0 {
+		config.PullInterval = time.Second * 5
 	}
 
 	if config.Logger == nil {

--- a/chrysom/client.go
+++ b/chrysom/client.go
@@ -251,9 +251,9 @@ func (c *Client) Push(item model.Item, owner string, adminMode bool) (PushResult
 
 	switch response.StatusCode {
 	case http.StatusCreated:
-		return CreatedSetResult, nil
+		return CreatedPushResult, nil
 	case http.StatusOK:
-		return UpdatedSetResult, nil
+		return UpdatedPushResult, nil
 	}
 
 	c.loggers.Error.Log("msg", "DB responded with non-successful response for request to update an item", "code", response.StatusCode)

--- a/chrysom/client.go
+++ b/chrysom/client.go
@@ -34,6 +34,16 @@ import (
 	"github.com/xmidt-org/bascule/acquire"
 )
 
+// SetResult is a simple type to indicate the result type for the
+// SetItem operation.
+type SetResult string
+
+// Types of set item successful results.
+const (
+	CreatedSetResult SetResult = "created"
+	UpdatedSetResult SetResult = "ok"
+)
+
 type ClientConfig struct {
 	HTTPClient      *http.Client
 	Bucket          string
@@ -44,6 +54,7 @@ type ClientConfig struct {
 	MetricsProvider provider.Provider
 	Logger          log.Logger
 	Listener        Listener
+	AdminToken      string
 }
 
 type Auth struct {
@@ -67,6 +78,7 @@ type Client struct {
 	remoteStoreAddress  string
 	defaultStoreItemTTL int64
 	loggers             loggerGroup
+	adminToken          string
 }
 
 func initLoggers(logger log.Logger) loggerGroup {
@@ -102,6 +114,7 @@ func CreateClient(config ClientConfig) (*Client, error) {
 		remoteStoreAddress:  config.Address,
 		defaultStoreItemTTL: config.DefaultTTL,
 		bucketName:          config.Bucket,
+		adminToken:          config.AdminToken,
 	}
 
 	if config.PullInterval > 0 {
@@ -133,6 +146,7 @@ func validateConfig(config *ClientConfig) error {
 	}
 	return nil
 }
+
 func determineTokenAcquirer(config ClientConfig) (acquire.Acquirer, error) {
 	defaultAcquirer := &acquire.DefaultAcquirer{}
 	if config.Auth.JWT.AuthURL != "" && config.Auth.JWT.Buffer != 0 && config.Auth.JWT.Timeout != 0 {
@@ -146,38 +160,46 @@ func determineTokenAcquirer(config ClientConfig) (acquire.Acquirer, error) {
 	return defaultAcquirer, nil
 }
 
-func (c *Client) GetItems(owner string) ([]model.Item, error) {
+func (c *Client) GetItems(owner string, adminMode bool) ([]model.Item, error) {
 	request, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/store/%s", c.remoteStoreAddress, c.bucketName), nil)
 	if err != nil {
-		return []model.Item{}, err
+		return nil, err
 	}
 	err = acquire.AddAuth(request, c.auth)
 	if err != nil {
-		return []model.Item{}, err
+		return nil, err
 	}
 	if owner != "" {
-		request.Header.Add("X-Midt-Owner", owner)
+		request.Header.Set("X-Midt-Owner", owner)
 	}
+
+	if adminMode {
+		if c.adminToken == "" {
+			return nil, errors.New("adminToken needed to run as admin")
+		}
+		request.Header.Set("X-Midt-Admin-Token", c.adminToken)
+	}
+
 	response, err := c.client.Do(request)
 	if err != nil {
-		return []model.Item{}, err
+		return nil, err
 	}
 	if response.StatusCode == 404 {
 		return []model.Item{}, nil
 	}
 	if response.StatusCode != 200 {
 		c.loggers.Error.Log("msg", "DB responded with non-200 response for request to get items", "code", response.StatusCode)
-		return []model.Item{}, errors.New("failed to get items, non 200 statuscode")
+		return nil, errors.New("failed to get items, non 200 statuscode")
 	}
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return []model.Item{}, err
+		return nil, err
 	}
 
 	body := map[string]model.Item{}
 	err = json.Unmarshal(data, &body)
 	if err != nil {
-		return []model.Item{}, err
+		return nil, err
 	}
 
 	responseData := make([]model.Item, len(body))
@@ -189,18 +211,24 @@ func (c *Client) GetItems(owner string) ([]model.Item, error) {
 	return responseData, nil
 }
 
-func (c *Client) Push(item model.Item, owner string) (string, error) {
+func (c *Client) Set(item model.Item, owner string, adminMode bool) (SetResult, error) {
 	if item.Identifier == "" {
 		return "", errors.New("identifier can't be empty")
 	}
-	if item.TTL < 1 {
-		item.TTL = c.defaultStoreItemTTL
+
+	if item.UUID == "" {
+		return "", errors.New("uuid can't be empty")
 	}
+
+	if item.TTL != nil && *item.TTL < 1 {
+		return "", errors.New("TTL must be > 0")
+	}
+
 	data, err := json.Marshal(&item)
 	if err != nil {
 		return "", err
 	}
-	request, err := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/store/%s", c.remoteStoreAddress, c.bucketName), bytes.NewReader(data))
+	request, err := http.NewRequest("PUT", fmt.Sprintf("%s/api/v1/store/%s/%s", c.remoteStoreAddress, c.bucketName, item.UUID), bytes.NewReader(data))
 	if err != nil {
 		return "", err
 	}
@@ -208,68 +236,36 @@ func (c *Client) Push(item model.Item, owner string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if owner != "" {
-		request.Header.Add("X-Midt-Owner", owner)
+	request.Header.Add("X-Midt-Owner", owner)
+
+	if adminMode {
+		if c.adminToken == "" {
+			return "", errors.New("adminToken needed to run as admin")
+		}
+		request.Header.Set("X-Midt-Admin-Token", c.adminToken)
 	}
+
 	response, err := c.client.Do(request)
 	if err != nil {
 		return "", err
 	}
-	if response.StatusCode != 200 {
-		c.loggers.Error.Log("msg", "DB responded with non-200 response for request to add/update an item", "code", response.StatusCode)
-		return "", errors.New("Failed to put item as DB responded with non-200 statuscode")
+
+	switch response.StatusCode {
+	case http.StatusCreated:
+		return CreatedSetResult, nil
+	case http.StatusOK:
+		return UpdatedSetResult, nil
 	}
-	responsePayload, _ := ioutil.ReadAll(response.Body)
-	key := model.Key{}
-	err = json.Unmarshal(responsePayload, &key)
-	if err != nil {
-		return "", err
-	}
-	return key.ID, nil
+
+	c.loggers.Error.Log("msg", "DB responded with non-successful response for request to update an item", "code", response.StatusCode)
+	return "", errors.New("Failed to set item as DB responded with non-success statuscode")
 }
 
-func (c *Client) Update(item model.Item, id string, owner string) (string, error) {
-	if item.Identifier == "" {
-		return "", errors.New("identifier can't be empty")
+func (c *Client) Remove(uuid string, owner string, adminMode bool) (model.Item, error) {
+	if uuid == "" {
+		return model.Item{}, errors.New("uuid can't be empty")
 	}
-	if item.TTL < 1 {
-		item.TTL = c.defaultStoreItemTTL
-	}
-	data, err := json.Marshal(&item)
-	if err != nil {
-		return "", err
-	}
-	request, err := http.NewRequest("PUT", fmt.Sprintf("%s/api/v1/store/%s/%s", c.remoteStoreAddress, c.bucketName, id), bytes.NewReader(data))
-	if err != nil {
-		return "", err
-	}
-	err = acquire.AddAuth(request, c.auth)
-	if err != nil {
-		return "", err
-	}
-	if owner != "" {
-		request.Header.Add("X-Midt-Owner", owner)
-	}
-	response, err := c.client.Do(request)
-	if err != nil {
-		return "", err
-	}
-	if response.StatusCode != 200 {
-		c.loggers.Error.Log("msg", "DB responded with non-200 response for request to update an item", "code", response.StatusCode)
-		return "", errors.New("Failed to put item as DB responded with non-200 statuscode")
-	}
-	responsePayload, _ := ioutil.ReadAll(response.Body)
-	key := model.Key{}
-	err = json.Unmarshal(responsePayload, &key)
-	if err != nil {
-		return "", err
-	}
-	return key.ID, nil
-
-}
-
-func (c *Client) Remove(id string, owner string) (model.Item, error) {
-	request, err := http.NewRequest("DELETE", fmt.Sprintf("%s/api/v1/store/%s/%s", c.remoteStoreAddress, c.bucketName, id), nil)
+	request, err := http.NewRequest("DELETE", fmt.Sprintf("%s/api/v1/store/%s/%s", c.remoteStoreAddress, c.bucketName, uuid), nil)
 	if err != nil {
 		return model.Item{}, err
 	}
@@ -277,9 +273,16 @@ func (c *Client) Remove(id string, owner string) (model.Item, error) {
 	if err != nil {
 		return model.Item{}, err
 	}
-	if owner != "" {
-		request.Header.Add("X-Midt-Owner", owner)
+
+	request.Header.Add("X-Midt-Owner", owner)
+
+	if adminMode {
+		if c.adminToken == "" {
+			return "", errors.New("adminToken needed to run as admin")
+		}
+		request.Header.Set("X-Midt-Admin-Token", c.adminToken)
 	}
+
 	response, err := c.client.Do(request)
 	if err != nil {
 		return model.Item{}, err
@@ -309,7 +312,7 @@ func (c *Client) Start(ctx context.Context) error {
 	go func() {
 		for range c.ticker.C {
 			outcome := SuccessOutcome
-			items, err := c.GetItems("")
+			items, err := c.GetItems("", true)
 			if err == nil {
 				c.listener.Update(items)
 			} else {

--- a/chrysom/store.go
+++ b/chrysom/store.go
@@ -32,10 +32,10 @@ type PushReader interface {
 type Pusher interface {
 	// Push applies user configurable for registering an item returning the id
 	// i.e. updated the storage with said item.
-	Push(item model.Item, owner string) (string, error)
+	Push(item model.Item, owner string, adminMode bool) (PushResult, error)
 
 	// Remove will remove the item from the store
-	Remove(id string, owner string) (model.Item, error)
+	Remove(uuid string, owner string, adminMode bool) (model.Item, error)
 }
 
 type Listener interface {
@@ -54,7 +54,7 @@ func (listener ListenerFunc) Update(items []model.Item) {
 
 type Reader interface {
 	// GeItems will return all the current items or an error.
-	GetItems(owner string) ([]model.Item, error)
+	GetItems(owner string, adminMode bool) ([]model.Item, error)
 
 	Start(ctx context.Context) error
 

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/go-kit/kit v0.9.0
 	github.com/go-playground/validator/v10 v10.3.0
 	github.com/gocql/gocql v0.0.0-20200505093417-effcbd8bcf0e
-	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.7.3
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
+	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab // indirect
 	github.com/justinas/alice v1.2.0
 	github.com/prometheus/client_golang v1.4.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,6 @@ github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
-github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/goph/emperror v0.17.1/go.mod h1:+ZbQ+fUNO/6FNiUo0ujtMjhgad9Xa6fQL9KhH4LNHic=
 github.com/goph/emperror v0.17.3-0.20190703203600-60a8d9faa17b h1:3/cwc6wu5QADzKEW2HP7+kZpKgm7OHysQ3ULVVQzQhs=
 github.com/goph/emperror v0.17.3-0.20190703203600-60a8d9faa17b/go.mod h1:+ZbQ+fUNO/6FNiUo0ujtMjhgad9Xa6fQL9KhH4LNHic=
@@ -139,6 +137,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/influxdata/influxdb v1.5.1-0.20180921190457-8d679cf0c36e/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb1-client v0.0.0-20200515024757-02f0bf5dbca3 h1:k3/6a1Shi7GGCp9QpyYuXsMM6ncTOjCzOE9Fd6CDA+Q=
 github.com/influxdata/influxdb1-client v0.0.0-20200515024757-02f0bf5dbca3/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab h1:HqW4xhhynfjrtEiiSGcQUd6vrK23iMam1FO8rI7mwig=
+github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=

--- a/model/model.go
+++ b/model/model.go
@@ -22,18 +22,25 @@ type Key struct {
 	// Bucket is a collection of items.
 	Bucket string `json:"bucket"`
 
-	// ID is the unique ID for an item in a bucket
-	ID string `json:"id"`
+	// UUID is the unique ID for an item in a bucket.
+	UUID string `json:"uuid"`
 }
 
 // Item defines the abstract item to be stored.
 type Item struct {
-	// Identifier is how the client refers to the object.
+	// UUID is the unique ID identifying this item. It is recommended this value is the resulting
+	// value of a SHA256 calculation, using the unique attributes of the object being represented
+	// (e.g. SHA256(<identifier>)). This will be used by argus to determine uniqueness of objects being stored or updated.
+	UUID string `json:"uuid"`
+
+	// Identifier is the common name of the provided resource. There is no enforcement of uniqueness
+	// across resource of this type.
 	Identifier string `json:"identifier"`
 
-	// Data is an abstract json object
+	// Data is the JSON object to be stored. Opaque to argus.
 	Data map[string]interface{} `json:"data"`
 
-	// TTL is the time to live in storage. If not provided and if the storage requires it the default configuration will be used.
-	TTL int64 `json:"ttl,omitempty"`
+	// TTL is the time to live in storage, specified in seconds.
+	// Optional. When not set, items don't expire.
+	TTL *int64 `json:"ttl,omitempty"`
 }

--- a/routes.go
+++ b/routes.go
@@ -92,8 +92,7 @@ type PrimaryRouter struct {
 
 type PrimaryRoutes struct {
 	fx.In
-	Push   store.Handler `name:"pushHandler"`
-	Update store.Handler `name:"updateHandler"`
+	Set    store.Handler `name:"setHandler"`
 	Delete store.Handler `name:"deleteHandler"`
 	Get    store.Handler `name:"getHandler"`
 	GetAll store.Handler `name:"getAllHandler"`
@@ -101,20 +100,17 @@ type PrimaryRoutes struct {
 
 func BuildPrimaryRoutes(router PrimaryRouter, routes PrimaryRoutes) {
 	router.Router.Use(router.AuthChain.Then)
-	if routes.Push != nil {
-		router.Router.Handle(fmt.Sprintf("/%s/store/{bucket}", apiBase), routes.Push).Methods(http.MethodPost)
-	}
-	if routes.Update != nil {
-		router.Router.Handle(fmt.Sprintf("/%s/store/{bucket}/{id}", apiBase), routes.Update).Methods(http.MethodPut)
+	if routes.Set != nil {
+		router.Router.Handle(fmt.Sprintf("/%s/store/{bucket}/{uuid}", apiBase), routes.Set).Methods(http.MethodPut)
 	}
 	if routes.Get != nil {
-		router.Router.Handle(fmt.Sprintf("/%s/store/{bucket}/{id}", apiBase), routes.Get).Methods(http.MethodGet)
+		router.Router.Handle(fmt.Sprintf("/%s/store/{bucket}/{uuid}", apiBase), routes.Get).Methods(http.MethodGet)
 	}
 	if routes.GetAll != nil {
 		router.Router.Handle(fmt.Sprintf("/%s/store/{bucket}", apiBase), routes.GetAll).Methods(http.MethodGet)
 	}
 	if routes.Delete != nil {
-		router.Router.Handle(fmt.Sprintf("/%s/store/{bucket}/{id}", apiBase), routes.Delete).Methods(http.MethodDelete)
+		router.Router.Handle(fmt.Sprintf("/%s/store/{bucket}/{uuid}", apiBase), routes.Delete).Methods(http.MethodDelete)
 	}
 }
 

--- a/store/endpoint.go
+++ b/store/endpoint.go
@@ -81,7 +81,7 @@ func newSetItemEndpoint(s S) endpoint.Endpoint {
 
 		if err != nil {
 			switch err.(type) {
-			case *KeyNotFoundError:
+			case KeyNotFoundError:
 				err = s.Push(setItemRequest.key, setItemRequest.item)
 				if err != nil {
 					return nil, err

--- a/store/endpoint.go
+++ b/store/endpoint.go
@@ -30,7 +30,7 @@ func newGetItemEndpoint(s S) endpoint.Endpoint {
 		if err != nil {
 			return nil, err
 		}
-		if itemRequest.owner == itemResponse.Owner {
+		if authorized(itemRequest.adminMode, itemResponse.Owner, itemRequest.owner) {
 			return &itemResponse, nil
 		}
 

--- a/store/endpoint_test.go
+++ b/store/endpoint_test.go
@@ -300,7 +300,7 @@ func TestSetItemEndpoint(t *testing.T) {
 					Owner: "cable",
 				},
 			},
-			GetDAOResponseErr: &KeyNotFoundError{},
+			GetDAOResponseErr: KeyNotFoundError{},
 			PushDAOResponse: OwnableItem{
 				Owner: "cable",
 				Item:  model.Item{},

--- a/store/endpoint_test.go
+++ b/store/endpoint_test.go
@@ -31,14 +31,14 @@ func TestGetItemEndpoint(t *testing.T) {
 			ItemRequest: &getOrDeleteItemRequest{
 				owner: "Kirby",
 				key: model.Key{
-					ID: "hammer",
+					UUID: "hammer",
 				},
 			},
 			DAOResponse: OwnableItem{
 				Owner: "Yoshi",
 			},
 			ExpectedErr: &KeyNotFoundError{Key: model.Key{
-				ID: "hammer",
+				UUID: "hammer",
 			}},
 		},
 		{
@@ -165,7 +165,7 @@ func TestDeleteItemEndpoint(t *testing.T) {
 func TestUpdateItemEndpoint(t *testing.T) {
 	testCases := []struct {
 		Name                 string
-		ItemRequest          *pushItemRequest
+		ItemRequest          *setItemRequest
 		UpdateDAOResponse    OwnableItem
 		UpdateDAOResponseErr error
 		GetDAOResponse       OwnableItem
@@ -175,10 +175,10 @@ func TestUpdateItemEndpoint(t *testing.T) {
 	}{
 		{
 			Name: "Update DAO failure",
-			ItemRequest: &pushItemRequest{
+			ItemRequest: &setItemRequest{
 				key: model.Key{
 					Bucket: "fruits",
-					ID:     "random-UUID",
+					UUID:   "random-UUID",
 				},
 				item: OwnableItem{
 					Item: model.Item{
@@ -195,10 +195,10 @@ func TestUpdateItemEndpoint(t *testing.T) {
 		},
 		{
 			Name: "Get DAO failure",
-			ItemRequest: &pushItemRequest{
+			ItemRequest: &setItemRequest{
 				key: model.Key{
 					Bucket: "fruits",
-					ID:     "random-UUID",
+					UUID:   "random-UUID",
 				},
 				item: OwnableItem{
 					Item: model.Item{
@@ -212,10 +212,10 @@ func TestUpdateItemEndpoint(t *testing.T) {
 		},
 		{
 			Name: "Wrong owner",
-			ItemRequest: &pushItemRequest{
+			ItemRequest: &setItemRequest{
 				key: model.Key{
 					Bucket: "fruits",
-					ID:     "random-UUID",
+					UUID:   "random-UUID",
 				},
 				item: OwnableItem{
 					Item:  model.Item{},
@@ -228,16 +228,16 @@ func TestUpdateItemEndpoint(t *testing.T) {
 			ExpectedErr: &KeyNotFoundError{
 				Key: model.Key{
 					Bucket: "fruits",
-					ID:     "random-UUID",
+					UUID:   "random-UUID",
 				},
 			},
 		},
 		{
 			Name: "Successful Update",
-			ItemRequest: &pushItemRequest{
+			ItemRequest: &setItemRequest{
 				key: model.Key{
 					Bucket: "fruits",
-					ID:     "random-UUID",
+					UUID:   "random-UUID",
 				},
 				item: OwnableItem{
 					Item:  model.Item{},
@@ -253,7 +253,7 @@ func TestUpdateItemEndpoint(t *testing.T) {
 			},
 			ExpectedResponse: &model.Key{
 				Bucket: "fruits",
-				ID:     "random-UUID",
+				UUID:   "random-UUID",
 			},
 		},
 	}
@@ -271,7 +271,7 @@ func TestUpdateItemEndpoint(t *testing.T) {
 
 			m.On("Get", testCase.ItemRequest.key).Return(testCase.GetDAOResponse, error(testCase.GetDAOResponseErr)).Once()
 
-			endpoint := newUpdateItemEndpoint(m)
+			endpoint := newSetItemEndpoint(m)
 			resp, err := endpoint(context.Background(), testCase.ItemRequest)
 
 			if testCase.ExpectedErr == nil {
@@ -359,7 +359,7 @@ func testPushItemEndpointHappyPath(t *testing.T) {
 	m := new(MockDAO)
 	key := model.Key{
 		Bucket: "fruits",
-		ID:     "strawberry",
+		UUID:   "strawberry",
 	}
 
 	item := OwnableItem{
@@ -370,8 +370,8 @@ func testPushItemEndpointHappyPath(t *testing.T) {
 	}
 
 	m.On("Push", key, item).Return(nil).Once()
-	endpoint := newPushItemEndpoint(m)
-	resp, err := endpoint(context.Background(), &pushItemRequest{
+	endpoint := newSetItemEndpoint(m)
+	resp, err := endpoint(context.Background(), &setItemRequest{
 		key:  key,
 		item: item,
 	})
@@ -384,8 +384,8 @@ func testPushItemEndpointDAOFails(t *testing.T) {
 	assert := assert.New(t)
 	m := new(MockDAO)
 	m.On("Push", model.Key{}, OwnableItem{}).Return(errors.New("DB failed")).Once()
-	endpoint := newPushItemEndpoint(m)
-	resp, err := endpoint(context.Background(), &pushItemRequest{})
+	endpoint := newSetItemEndpoint(m)
+	resp, err := endpoint(context.Background(), &setItemRequest{})
 	assert.Nil(resp)
 	assert.Equal(errors.New("DB failed"), err)
 	m.AssertExpectations(t)

--- a/store/endpoint_test.go
+++ b/store/endpoint_test.go
@@ -37,9 +37,25 @@ func TestGetItemEndpoint(t *testing.T) {
 			DAOResponse: OwnableItem{
 				Owner: "Yoshi",
 			},
-			ExpectedErr: &KeyNotFoundError{Key: model.Key{
-				UUID: "hammer",
-			}},
+			ExpectedErr: accessDeniedErr,
+		},
+
+		{
+			Name: "Wrong owner but admin mode",
+			ItemRequest: &getOrDeleteItemRequest{
+				owner: "Kirby",
+				key: model.Key{
+					UUID: "hammer",
+				},
+				adminMode: true,
+			},
+			DAOResponse: OwnableItem{
+				Owner: "Yoshi",
+			},
+
+			ExpectedResponse: &OwnableItem{
+				Owner: "Yoshi",
+			},
 		},
 		{
 			Name: "Success",
@@ -102,8 +118,28 @@ func TestDeleteItemEndpoint(t *testing.T) {
 			GetDAOResponse: OwnableItem{
 				Owner: "fiber",
 			},
-			ExpectedErr: &KeyNotFoundError{},
+			ExpectedErr: accessDeniedErr,
 		},
+
+		{
+			Name: "Wrong owner but admin mode",
+			ItemRequest: &getOrDeleteItemRequest{
+				owner:     "cable",
+				adminMode: true,
+			},
+			GetDAOResponse: OwnableItem{
+				Owner: "fiber",
+			},
+
+			DeleteDAOResponse: OwnableItem{
+				Owner: "fiber",
+			},
+
+			ExpectedResponse: &OwnableItem{
+				Owner: "fiber",
+			},
+		},
+
 		{
 			Name: "Deletion fails",
 			ItemRequest: &getOrDeleteItemRequest{
@@ -140,7 +176,7 @@ func TestDeleteItemEndpoint(t *testing.T) {
 			m.On("Get", testCase.ItemRequest.key).Return(testCase.GetDAOResponse, error(testCase.GetDAOResponseErr)).Once()
 
 			// verify item is not deleted by user who doesn't own it
-			allowDelete := testCase.ItemRequest.owner == "" || testCase.ItemRequest.owner == testCase.GetDAOResponse.Owner
+			allowDelete := testCase.ItemRequest.adminMode || testCase.ItemRequest.owner == testCase.GetDAOResponse.Owner
 
 			if testCase.GetDAOResponseErr != nil || !allowDelete {
 				m.AssertNotCalled(t, "Delete", testCase.ItemRequest)
@@ -162,23 +198,23 @@ func TestDeleteItemEndpoint(t *testing.T) {
 	}
 }
 
-func TestUpdateItemEndpoint(t *testing.T) {
+func TestSetItemEndpoint(t *testing.T) {
 	testCases := []struct {
-		Name                 string
-		ItemRequest          *setItemRequest
-		UpdateDAOResponse    OwnableItem
-		UpdateDAOResponseErr error
-		GetDAOResponse       OwnableItem
-		GetDAOResponseErr    error
-		ExpectedResponse     *model.Key
-		ExpectedErr          error
+		Name               string
+		ItemRequest        *setItemRequest
+		PushDAOResponse    OwnableItem
+		PushDAOResponseErr error
+		GetDAOResponse     OwnableItem
+		GetDAOResponseErr  error
+		ExpectedResponse   *setItemResponse
+		ExpectedErr        error
 	}{
 		{
-			Name: "Update DAO failure",
+			Name: "Push DAO failure",
 			ItemRequest: &setItemRequest{
 				key: model.Key{
 					Bucket: "fruits",
-					UUID:   "random-UUID",
+					UUID:   "XnN_iR2xF1RCo5_ec-UdeBpUVQbXHJVHem3rWYi9f5o",
 				},
 				item: OwnableItem{
 					Item: model.Item{
@@ -190,15 +226,15 @@ func TestUpdateItemEndpoint(t *testing.T) {
 			GetDAOResponse: OwnableItem{
 				Owner: "Bob",
 			},
-			UpdateDAOResponseErr: errors.New("DB failed"),
-			ExpectedErr:          errors.New("DB failed"),
+			PushDAOResponseErr: errors.New("DB failed"),
+			ExpectedErr:        errors.New("DB failed"),
 		},
 		{
 			Name: "Get DAO failure",
 			ItemRequest: &setItemRequest{
 				key: model.Key{
 					Bucket: "fruits",
-					UUID:   "random-UUID",
+					UUID:   "XnN_iR2xF1RCo5_ec-UdeBpUVQbXHJVHem3rWYi9f5o",
 				},
 				item: OwnableItem{
 					Item: model.Item{
@@ -215,7 +251,7 @@ func TestUpdateItemEndpoint(t *testing.T) {
 			ItemRequest: &setItemRequest{
 				key: model.Key{
 					Bucket: "fruits",
-					UUID:   "random-UUID",
+					UUID:   "XnN_iR2xF1RCo5_ec-UdeBpUVQbXHJVHem3rWYi9f5o",
 				},
 				item: OwnableItem{
 					Item:  model.Item{},
@@ -225,35 +261,52 @@ func TestUpdateItemEndpoint(t *testing.T) {
 			GetDAOResponse: OwnableItem{
 				Owner: "fiber",
 			},
-			ExpectedErr: &KeyNotFoundError{
-				Key: model.Key{
-					Bucket: "fruits",
-					UUID:   "random-UUID",
-				},
-			},
+			ExpectedErr: accessDeniedErr,
 		},
 		{
-			Name: "Successful Update",
+			Name: "Successful Update. Wrong owner but admin mode",
 			ItemRequest: &setItemRequest{
 				key: model.Key{
 					Bucket: "fruits",
-					UUID:   "random-UUID",
+					UUID:   "XnN_iR2xF1RCo5_ec-UdeBpUVQbXHJVHem3rWYi9f5o",
+				},
+				item: OwnableItem{
+					Item:  model.Item{},
+					Owner: "cable",
+				},
+				adminMode: true,
+			},
+			GetDAOResponse: OwnableItem{
+				Owner: "cable",
+			},
+			PushDAOResponse: OwnableItem{
+				Owner: "cable",
+				Item:  model.Item{},
+			},
+			ExpectedResponse: &setItemResponse{
+				existingResource: true,
+			},
+		},
+
+		{
+			Name: "Successful Creation",
+			ItemRequest: &setItemRequest{
+				key: model.Key{
+					Bucket: "fruits",
+					UUID:   "XnN_iR2xF1RCo5_ec-UdeBpUVQbXHJVHem3rWYi9f5o",
 				},
 				item: OwnableItem{
 					Item:  model.Item{},
 					Owner: "cable",
 				},
 			},
-			GetDAOResponse: OwnableItem{
-				Owner: "cable",
-			},
-			UpdateDAOResponse: OwnableItem{
+			GetDAOResponseErr: &KeyNotFoundError{},
+			PushDAOResponse: OwnableItem{
 				Owner: "cable",
 				Item:  model.Item{},
 			},
-			ExpectedResponse: &model.Key{
-				Bucket: "fruits",
-				UUID:   "random-UUID",
+			ExpectedResponse: &setItemResponse{
+				existingResource: false,
 			},
 		},
 	}
@@ -263,10 +316,10 @@ func TestUpdateItemEndpoint(t *testing.T) {
 			assert := assert.New(t)
 			m := new(MockDAO)
 
-			if testCase.UpdateDAOResponseErr == nil {
+			if testCase.PushDAOResponseErr == nil {
 				m.On("Push", testCase.ItemRequest.key, testCase.ItemRequest.item).Return(nil).Once()
 			} else {
-				m.On("Push", testCase.ItemRequest.key, testCase.ItemRequest.item).Return(testCase.UpdateDAOResponseErr).Once()
+				m.On("Push", testCase.ItemRequest.key, testCase.ItemRequest.item).Return(testCase.PushDAOResponseErr).Once()
 			}
 
 			m.On("Get", testCase.ItemRequest.key).Return(testCase.GetDAOResponse, error(testCase.GetDAOResponseErr)).Once()
@@ -276,117 +329,137 @@ func TestUpdateItemEndpoint(t *testing.T) {
 
 			if testCase.ExpectedErr == nil {
 				assert.Nil(err)
-				assert.Equal(&testCase.ItemRequest.key, resp)
+				assert.Equal(testCase.ExpectedResponse, resp)
 				m.AssertExpectations(t)
 			} else {
 				assert.Equal(testCase.ExpectedErr, err)
 			}
-
 		})
 	}
 }
 
 func TestGetAllItemsEndpoint(t *testing.T) {
-	t.Run("DAOFails", testGetAllItemsEndpointDAOFails)
-	t.Run("FilteredItems", testGetAllItemsEndpointFiltered)
-}
+	testCases := []struct {
+		Name                 string
+		ItemRequest          *getAllItemsRequest
+		GetAllDAOResponse    map[string]OwnableItem
+		GetAllDAOResponseErr error
+		ExpectedResponse     map[string]OwnableItem
+		ExpectedErr          error
+	}{
+		{
+			Name: "DAO failure",
+			ItemRequest: &getAllItemsRequest{
+				bucket: "sports-cars",
+				owner:  "alfa-romeo",
+			},
+			GetAllDAOResponseErr: errors.New("DB failed"),
+			ExpectedErr:          errors.New("DB failed"),
+		},
+		{
+			Name: "Filtered results",
+			ItemRequest: &getAllItemsRequest{
+				bucket: "sports-cars",
+				owner:  "alfa-romeo",
+			},
+			GetAllDAOResponse: map[string]OwnableItem{
+				"mustang": OwnableItem{
+					Owner: "ford",
+				},
+				"4c-spider": OwnableItem{
+					Owner: "alfa-romeo",
+				},
+				"gtr": OwnableItem{
+					Owner: "nissan",
+				},
+				"giulia": OwnableItem{
+					Owner: "alfa-romeo",
+				},
+			},
 
-func testGetAllItemsEndpointDAOFails(t *testing.T) {
-	assert := assert.New(t)
-	m := new(MockDAO)
-	itemsRequest := &getAllItemsRequest{
-		bucket: "sports-cars",
-		owner:  "alfa-romeo",
+			ExpectedResponse: map[string]OwnableItem{
+				"4c-spider": OwnableItem{
+					Owner: "alfa-romeo",
+				},
+
+				"giulia": OwnableItem{
+					Owner: "alfa-romeo",
+				},
+			},
+		},
+
+		{
+			Name: "Admin mode",
+			ItemRequest: &getAllItemsRequest{
+				bucket:    "sports-cars",
+				owner:     "alfa-romeo",
+				adminMode: true,
+			},
+			GetAllDAOResponse: map[string]OwnableItem{
+				"mustang": OwnableItem{
+					Owner: "ford",
+				},
+				"4c-spider": OwnableItem{
+					Owner: "alfa-romeo",
+				},
+				"gtr": OwnableItem{
+					Owner: "nissan",
+				},
+				"giulia": OwnableItem{
+					Owner: "alfa-romeo",
+				},
+			},
+
+			ExpectedResponse: map[string]OwnableItem{
+				"mustang": OwnableItem{
+					Owner: "ford",
+				},
+				"4c-spider": OwnableItem{
+					Owner: "alfa-romeo",
+				},
+				"gtr": OwnableItem{
+					Owner: "nissan",
+				},
+				"giulia": OwnableItem{
+					Owner: "alfa-romeo",
+				},
+			},
+		},
+
+		{
+			Name: "Empty results",
+			ItemRequest: &getAllItemsRequest{
+				bucket: "sports-cars",
+				owner:  "volkswagen",
+			},
+			GetAllDAOResponse: map[string]OwnableItem{
+				"mustang": OwnableItem{
+					Owner: "ford",
+				},
+				"giulia": OwnableItem{
+					Owner: "alfa-romeo",
+				},
+			},
+
+			ExpectedResponse: map[string]OwnableItem{},
+		},
 	}
-	mockedErr := errors.New("sports cars api is down")
-	m.On("GetAll", "sports-cars").Return(map[string]OwnableItem{}, mockedErr).Once()
 
-	endpoint := newGetAllItemsEndpoint(m)
-	resp, err := endpoint(context.Background(), itemsRequest)
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			assert := assert.New(t)
+			m := new(MockDAO)
 
-	assert.Nil(resp)
-	assert.Equal(mockedErr, err)
-	m.AssertExpectations(t)
-}
+			m.On("GetAll", testCase.ItemRequest.bucket).Return(testCase.GetAllDAOResponse, error(testCase.GetAllDAOResponseErr))
 
-func testGetAllItemsEndpointFiltered(t *testing.T) {
-	assert := assert.New(t)
-	m := new(MockDAO)
-	itemsRequest := &getAllItemsRequest{
-		bucket: "sports-cars",
-		owner:  "alfa-romeo",
+			endpoint := newGetAllItemsEndpoint(m)
+			resp, err := endpoint(context.Background(), testCase.ItemRequest)
+			if testCase.ExpectedErr == nil {
+				assert.Nil(err)
+				assert.Equal(testCase.ExpectedResponse, resp)
+			} else {
+				assert.Equal(testCase.ExpectedErr, err)
+			}
+		})
 	}
-	mockedItems := map[string]OwnableItem{
-		"mustang": OwnableItem{
-			Owner: "ford",
-		},
-		"4c-spider": OwnableItem{
-			Owner: "alfa-romeo",
-		},
-		"gtr": OwnableItem{
-			Owner: "nissan",
-		},
-		"giulia": OwnableItem{
-			Owner: "alfa-romeo",
-		},
-	}
-	m.On("GetAll", "sports-cars").Return(mockedItems, error(nil)).Once()
-
-	endpoint := newGetAllItemsEndpoint(m)
-	resp, err := endpoint(context.Background(), itemsRequest)
-
-	expectedItems := map[string]OwnableItem{
-		"4c-spider": OwnableItem{
-			Owner: "alfa-romeo",
-		},
-		"giulia": OwnableItem{
-			Owner: "alfa-romeo",
-		},
-	}
-
-	assert.Equal(expectedItems, resp)
-	assert.Nil(err)
-	m.AssertExpectations(t)
-}
-
-func TestPushItemEndpoint(t *testing.T) {
-	t.Run("DAOFails", testPushItemEndpointDAOFails)
-	t.Run("Happy Path", testPushItemEndpointHappyPath)
-}
-
-func testPushItemEndpointHappyPath(t *testing.T) {
-	assert := assert.New(t)
-	m := new(MockDAO)
-	key := model.Key{
-		Bucket: "fruits",
-		UUID:   "strawberry",
-	}
-
-	item := OwnableItem{
-		Item: model.Item{
-			Identifier: "strawberry",
-		},
-		Owner: "Bob",
-	}
-
-	m.On("Push", key, item).Return(nil).Once()
-	endpoint := newSetItemEndpoint(m)
-	resp, err := endpoint(context.Background(), &setItemRequest{
-		key:  key,
-		item: item,
-	})
-	assert.Nil(err)
-	assert.Equal(&key, resp)
-	m.AssertExpectations(t)
-}
-
-func testPushItemEndpointDAOFails(t *testing.T) {
-	assert := assert.New(t)
-	m := new(MockDAO)
-	m.On("Push", model.Key{}, OwnableItem{}).Return(errors.New("DB failed")).Once()
-	endpoint := newSetItemEndpoint(m)
-	resp, err := endpoint(context.Background(), &setItemRequest{})
-	assert.Nil(resp)
-	assert.Equal(errors.New("DB failed"), err)
-	m.AssertExpectations(t)
 }

--- a/store/errors.go
+++ b/store/errors.go
@@ -19,18 +19,30 @@ func (bre BadRequestErr) StatusCode() int {
 	return http.StatusBadRequest
 }
 
+type ForbiddenRequestErr struct {
+	Message string
+}
+
+func (f ForbiddenRequestErr) Error() string {
+	return f.Message
+}
+
+func (f ForbiddenRequestErr) StatusCode() int {
+	return http.StatusForbidden
+}
+
 type KeyNotFoundError struct {
 	Key model.Key
 }
 
 func (knfe KeyNotFoundError) Error() string {
-	if knfe.Key.ID == "" && knfe.Key.Bucket == "" {
+	if knfe.Key.UUID == "" && knfe.Key.Bucket == "" {
 		return fmt.Sprint("parameters for key not set")
-	} else if knfe.Key.ID == "" && knfe.Key.Bucket != "" {
+	} else if knfe.Key.UUID == "" && knfe.Key.Bucket != "" {
 		return fmt.Sprintf("no value exists for bucket %s", knfe.Key.Bucket)
 
 	}
-	return fmt.Sprintf("no value exists with bucket: %s, id: %s", knfe.Key.Bucket, knfe.Key.ID)
+	return fmt.Sprintf("no value exists with bucket: %s, uuid: %s", knfe.Key.Bucket, knfe.Key.UUID)
 }
 
 func (knfe KeyNotFoundError) StatusCode() int {

--- a/store/handler.go
+++ b/store/handler.go
@@ -19,7 +19,6 @@ package store
 
 import (
 	"net/http"
-	"time"
 
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/xmidt-org/argus/model"
@@ -33,41 +32,37 @@ type KeyItemPairRequest struct {
 	Method string
 }
 
-type ItemTTL struct {
-	MaxTTL time.Duration
-}
-
-func newGetItemHandler(s S) Handler {
+func newGetItemHandler(config *requestConfig, s S) Handler {
 	return kithttp.NewServer(
 		newGetItemEndpoint(s),
-		decodeGetOrDeleteItemRequest,
+		getOrDeleteItemRequestDecoder(config),
 		encodeGetOrDeleteItemResponse,
 		kithttp.ServerErrorEncoder(encodeError),
 	)
 }
 
-func newDeleteItemHandler(s S) Handler {
+func newDeleteItemHandler(config *requestConfig, s S) Handler {
 	return kithttp.NewServer(
 		newDeleteItemEndpoint(s),
-		decodeGetOrDeleteItemRequest,
+		getOrDeleteItemRequestDecoder(config),
 		encodeGetOrDeleteItemResponse,
 		kithttp.ServerErrorEncoder(encodeError),
 	)
 }
 
-func newGetAllItemsHandler(s S) Handler {
+func newGetAllItemsHandler(config *requestConfig, s S) Handler {
 	return kithttp.NewServer(
 		newGetAllItemsEndpoint(s),
-		decodeGetAllItemsRequest,
+		getAllItemsRequestDecoder(config),
 		encodeGetAllItemsResponse,
 		kithttp.ServerErrorEncoder(encodeError),
 	)
 }
 
-func newSetItemHandler(itemTTLInfo ItemTTL, s S) Handler {
+func newSetItemHandler(config *requestConfig, s S) Handler {
 	return kithttp.NewServer(
 		newSetItemEndpoint(s),
-		setItemRequestDecoder(itemTTLInfo),
+		setItemRequestDecoder(config),
 		encodeSetItemResponse,
 		kithttp.ServerErrorEncoder(encodeError),
 	)

--- a/store/handler.go
+++ b/store/handler.go
@@ -34,8 +34,7 @@ type KeyItemPairRequest struct {
 }
 
 type ItemTTL struct {
-	DefaultTTL time.Duration
-	MaxTTL     time.Duration
+	MaxTTL time.Duration
 }
 
 func newGetItemHandler(s S) Handler {
@@ -65,20 +64,11 @@ func newGetAllItemsHandler(s S) Handler {
 	)
 }
 
-func newPushItemHandler(itemTTLInfo ItemTTL, s S) Handler {
+func newSetItemHandler(itemTTLInfo ItemTTL, s S) Handler {
 	return kithttp.NewServer(
-		newPushItemEndpoint(s),
-		pushItemRequestDecoder(itemTTLInfo, false),
-		encodePushItemResponse,
-		kithttp.ServerErrorEncoder(encodeError),
-	)
-}
-
-func newUpdateItemHandler(itemTTLInfo ItemTTL, s S) Handler {
-	return kithttp.NewServer(
-		newUpdateItemEndpoint(s),
-		pushItemRequestDecoder(itemTTLInfo, true),
-		encodePushItemResponse,
+		newSetItemEndpoint(s),
+		setItemRequestDecoder(itemTTLInfo),
+		encodeSetItemResponse,
 		kithttp.ServerErrorEncoder(encodeError),
 	)
 }

--- a/store/inmem/InMem.go
+++ b/store/inmem/InMem.go
@@ -18,9 +18,10 @@
 package inmem
 
 import (
+	"sync"
+
 	"github.com/xmidt-org/argus/model"
 	"github.com/xmidt-org/argus/store"
-	"sync"
 )
 
 type InMem struct {
@@ -38,10 +39,10 @@ func (i *InMem) Push(key model.Key, item store.OwnableItem) error {
 	i.lock.Lock()
 	if _, ok := i.data[key.Bucket]; !ok {
 		i.data[key.Bucket] = map[string]store.OwnableItem{
-			key.ID: item,
+			key.UUID: item,
 		}
 	} else {
-		i.data[key.Bucket][key.ID] = item
+		i.data[key.Bucket][key.UUID] = item
 	}
 	i.lock.Unlock()
 	return nil
@@ -56,7 +57,7 @@ func (i *InMem) Get(key model.Key) (store.OwnableItem, error) {
 	if _, ok := i.data[key.Bucket]; !ok {
 		err = store.KeyNotFoundError{Key: key}
 	} else {
-		if value, ok := i.data[key.Bucket][key.ID]; !ok {
+		if value, ok := i.data[key.Bucket][key.UUID]; !ok {
 			err = store.KeyNotFoundError{Key: key}
 		} else {
 			item = value
@@ -78,7 +79,7 @@ func (i *InMem) GetAll(bucket string) (map[string]store.OwnableItem, error) {
 	} else {
 		err = store.KeyNotFoundError{Key: model.Key{
 			Bucket: bucket,
-			ID:     "",
+			UUID:   "",
 		}}
 	}
 	i.lock.RUnlock()
@@ -94,11 +95,11 @@ func (i *InMem) Delete(key model.Key) (store.OwnableItem, error) {
 	if _, ok := i.data[key.Bucket]; !ok {
 		err = store.KeyNotFoundError{Key: key}
 	} else {
-		if value, ok := i.data[key.Bucket][key.ID]; !ok {
+		if value, ok := i.data[key.Bucket][key.UUID]; !ok {
 			err = store.KeyNotFoundError{Key: key}
 		} else {
 			item = value
-			delete(i.data[key.Bucket], key.ID)
+			delete(i.data[key.Bucket], key.UUID)
 		}
 	}
 	i.lock.Unlock()

--- a/store/provide.go
+++ b/store/provide.go
@@ -50,22 +50,20 @@ type StoreOut struct {
 
 // Provide is an uber/fx style provider for this package's components
 func Provide(unmarshaller config.Unmarshaller, in StoreIn) StoreOut {
-	itemTTL := ItemTTL{
-		MaxTTL: YearTTL,
-	}
-	unmarshaller.UnmarshalKey("itemTTL", itemTTL)
-	validateItemTTLConfig(&itemTTL)
+	cfg := new(requestConfig)
+	unmarshaller.UnmarshalKey("request", cfg)
+	validateRequestConfig(cfg)
 
 	return StoreOut{
-		SetItemHandler:     newSetItemHandler(itemTTL, in.Store),
-		GetItemHandler:     newGetItemHandler(in.Store),
-		GetAllItemsHandler: newGetAllItemsHandler(in.Store),
-		DeleteKeyHandler:   newDeleteItemHandler(in.Store),
+		SetItemHandler:     newSetItemHandler(cfg, in.Store),
+		GetItemHandler:     newGetItemHandler(cfg, in.Store),
+		GetAllItemsHandler: newGetAllItemsHandler(cfg, in.Store),
+		DeleteKeyHandler:   newDeleteItemHandler(cfg, in.Store),
 	}
 }
 
-func validateItemTTLConfig(ttl *ItemTTL) {
-	if ttl.MaxTTL <= time.Second {
-		ttl.MaxTTL = YearTTL * time.Second
+func validateRequestConfig(cfg *requestConfig) {
+	if cfg.Validation.MaxTTL <= time.Second {
+		cfg.Validation.MaxTTL = YearTTL * time.Second
 	}
 }

--- a/store/provide.go
+++ b/store/provide.go
@@ -35,11 +35,8 @@ type StoreIn struct {
 type StoreOut struct {
 	fx.Out
 
-	// PushItemHandler is the http.Handler to add a new item to the store.
-	PushItemHandler Handler `name:"pushHandler"`
-
 	// SetItemHandler is the http.Handler to update an item in the store.
-	UpdateItemHandler Handler `name:"updateHandler"`
+	SetItemHandler Handler `name:"setHandler"`
 
 	// SetKeyHandler is the http.Handler to fetch an individual item from the store.
 	GetItemHandler Handler `name:"getHandler"`
@@ -54,15 +51,13 @@ type StoreOut struct {
 // Provide is an uber/fx style provider for this package's components
 func Provide(unmarshaller config.Unmarshaller, in StoreIn) StoreOut {
 	itemTTL := ItemTTL{
-		DefaultTTL: DefaultTTL,
-		MaxTTL:     YearTTL,
+		MaxTTL: YearTTL,
 	}
 	unmarshaller.UnmarshalKey("itemTTL", itemTTL)
 	validateItemTTLConfig(&itemTTL)
 
 	return StoreOut{
-		PushItemHandler:    newPushItemHandler(itemTTL, in.Store),
-		UpdateItemHandler:  newUpdateItemHandler(itemTTL, in.Store),
+		SetItemHandler:     newSetItemHandler(itemTTL, in.Store),
 		GetItemHandler:     newGetItemHandler(in.Store),
 		GetAllItemsHandler: newGetAllItemsHandler(in.Store),
 		DeleteKeyHandler:   newDeleteItemHandler(in.Store),
@@ -72,8 +67,5 @@ func Provide(unmarshaller config.Unmarshaller, in StoreIn) StoreOut {
 func validateItemTTLConfig(ttl *ItemTTL) {
 	if ttl.MaxTTL <= time.Second {
 		ttl.MaxTTL = YearTTL * time.Second
-	}
-	if ttl.DefaultTTL <= time.Millisecond {
-		ttl.DefaultTTL = DefaultTTL * time.Second
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -51,10 +51,6 @@ type OwnableItem struct {
 }
 
 func FilterOwner(value map[string]OwnableItem, owner string) map[string]OwnableItem {
-	if owner == "" {
-		return value
-	}
-
 	filteredResults := map[string]OwnableItem{}
 	for k, v := range value {
 		if v.Owner == owner {

--- a/store/test/storetest.go
+++ b/store/test/storetest.go
@@ -18,17 +18,19 @@
 package test
 
 import (
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xmidt-org/argus/model"
 	"github.com/xmidt-org/argus/store"
-	"testing"
-	"time"
 )
 
+var testInt int64 = 3
 var GenericTestKeyPair = store.KeyItemPairRequest{
 	Key: model.Key{
 		Bucket: "world",
-		ID:     "earth",
+		UUID:   "earth",
 	},
 	OwnableItem: store.OwnableItem{
 		Item: model.Item{
@@ -37,7 +39,7 @@ var GenericTestKeyPair = store.KeyItemPairRequest{
 				"year":  float64(1967),
 				"words": []interface{}{"What", "a", "Wonderful", "World"},
 			},
-			TTL: 3,
+			TTL: &testInt,
 		},
 		Owner: "Louis Armstrong",
 	},

--- a/store/transport_test.go
+++ b/store/transport_test.go
@@ -226,7 +226,7 @@ func TestsetItemRequestDecoder(t *testing.T) {
 			Name:        "Bad JSON data",
 			URLVars:     map[string]string{bucketVarKey: "bucketVal", uuidVarKey: "rWPSg7pI0jj8mMG9tmscdQMOGKeRAquySfkObTasRBc"},
 			RequestBody: `{"validJSON": false,}`,
-			ExpectedErr: &BadRequestErr{
+			ExpectedErr: BadRequestErr{
 				Message: "failed to unmarshal json",
 			},
 		},
@@ -234,7 +234,7 @@ func TestsetItemRequestDecoder(t *testing.T) {
 			Name:        "Missing data item field",
 			URLVars:     map[string]string{bucketVarKey: "letters", uuidVarKey: "ypeBEsobvcr6wjGzmiPcTaeG7_gUfE5yuYB3ha_uSLs"},
 			RequestBody: `{"uuid": "ypeBEsobvcr6wjGzmiPcTaeG7_gUfE5yuYB3ha_uSLs","identifier": "a"}`,
-			ExpectedErr: &BadRequestErr{
+			ExpectedErr: BadRequestErr{
 				Message: "data field must be set",
 			},
 		},


### PR DESCRIPTION
Main changes introduced:
- If no TTL is specified by user, the item does not expire.

- UUID generation is now left to the user. 

- The low level functions that interact with the database no longer return expired items. This allows not having to do this check at the transport layer. 

