### PR TITLE
Add configurable owner validator in transport conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update buildtime format in Makefile to match RPM spec file. [#95](https://github.com/xmidt-org/argus/pull/95)
 - Update configuration structure for inbound authn/z. [#101](https://github.com/xmidt-org/argus/pull/101)
 - Admin mode flag now originates from JWT claims instead of an HTTP header. [#112](https://github.com/xmidt-org/argus/pull/112)
-- Add bucket validation. [#114](https://github.com/xmidt-org/argus/pull/114)
 - Remove stored loggers. [#118](https://github.com/xmidt-org/argus/pull/118)
 - Drop use of admin token headers from client. [#118](https://github.com/xmidt-org/argus/pull/118)
 
@@ -21,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Item ID is validated to have the format of a SHA256 message hex digest. [#106](https://github.com/xmidt-org/argus/pull/106)
+- Configurable item owner validation. [#121](https://github.com/xmidt-org/argus/pull/121)
+- Configurable item bucket validation. [#114](https://github.com/xmidt-org/argus/pull/114)
 
 ### Removed
 - Removed identifier as a field from the API. [#85](https://github.com/xmidt-org/argus/pull/85)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This endpoint allows for clients to `PUT` an object into argus.  The placeholder
     - Bucket names must be between 3 and 63 characters long.
     - Bucket names can consist only of lowercase letters, numbers and hyphens (-).
     - Bucket names must begin and end with a letter or number. 
+
   If you'd like to define your own bucket validation format, check out the `userInputValidation.bucketFormatRegex` configuration option.
 * _id_ - The unique ID within the name space of the containing bucket.  It is recommended this value is the resulting value of a SHA256 calculation, using the unique attributes of the object being represented (e.g. `SHA256(<common_name>)`).  This will be used by argus to determine uniqueness of objects being stored or updated.  argus will not accept any values for this attribute that is not a 64 character hex string.
 
@@ -48,7 +49,9 @@ The body must be in JSON format with the following attributes:
 
 * _id_ - Required.  See above.
 * _data_ - Required.  RAW JSON to be stored.  Opaque to argus.
-* _owner_ - Optional.  Free form string to identify the owner of this object.
+* _owner_ - Optional.  Free form string to identify the owner of this object. 
+
+By default, Argus validates the length of the owner string to be in the range `[10,60]`. If you'd like to define your own validation format, check out the `userInputValidation.ownerFormatRegex` configuration option.
 * _ttl_ - Optional.  Specified in units of seconds.  Defaults to the value of the server configuration option `itemMaxTTL`. If a configuration value is not specified, the value would be a day (~ 24*60^2 seconds).
 )
 

--- a/argus.yaml
+++ b/argus.yaml
@@ -114,6 +114,9 @@ userInputValidation:
   # bucketFormatRegex helps define the validity of a bucket through a regular expression.
   bucketFormatRegex: "^[0-9a-z][0-9a-z-]{1,61}[0-9a-z]$"
 
+  # ownerFormatRegex helps define the validity of a bucket through a regular expression.
+  ownerFormatRegex: "^.{10,60}$"
+
 
 ##############################################################################
 # Authorization Credentials

--- a/deploy/packaging/argus_spruce.yaml
+++ b/deploy/packaging/argus_spruce.yaml
@@ -135,6 +135,9 @@ userInputValidation:
   # bucketFormatRegex helps define the validity of a bucket through a regular expression.
   bucketFormatRegex: (( grab $BUCKET_FORMAT_REGEX || "^[0-9a-z][0-9a-z-]{1,61}[0-9a-z]$" ))
 
+  # ownerFormatRegex helps define the validity of a bucket through a regular expression.
+  ownerFormatRegex: (( grab $OWNER_FORMAT_REGEX || "^.{10,60}$" ))
+
 
 ##############################################################################
 # Authorization Credentials

--- a/store/inputValidation.go
+++ b/store/inputValidation.go
@@ -41,7 +41,7 @@ func isIDValid(idFormatRegex *regexp.Regexp, normalizedID string) bool {
 	return idFormatRegex.MatchString(normalizedID)
 }
 
-// isBucketValid return true if and only if all the following rules are satisfied. False otherwise.
+// isBucketValid returns true if and only if all the following rules are satisfied. False otherwise.
 // 1) Between 3 and 63 characters long.
 // 2) Consists only of lowercase letters, numbers and hyphens (-).
 // 3) Must begin and end with a letter or number.
@@ -49,15 +49,25 @@ func isBucketValid(bucketFormatRegex *regexp.Regexp, bucket string) bool {
 	return bucketFormatRegex.MatchString(bucket)
 }
 
-// validateItemPathVars returns a pertinent HTTP-coded error if any of the input variables
+// isOwnerValid returns true iff the owner is the string zero value (since the owner value is optional)
+// or it matches the configurable ownerFormat regex.
+func isOwnerValid(ownerFormatRegex *regexp.Regexp, owner string) bool {
+	return len(owner) < 1 || ownerFormatRegex.MatchString(owner)
+}
+
+// validateItemRequestVars returns a pertinent HTTP-coded error if any of the input variables
 // are invalid, nil otherwise.
-func validateItemPathVars(config *transportConfig, bucket, normalizedID string) error {
+func validateItemRequestVars(config *transportConfig, owner, bucket, normalizedID string) error {
 	if !isIDValid(config.IDFormatRegex, normalizedID) {
 		return errInvalidID
 	}
 
 	if !isBucketValid(config.BucketFormatRegex, bucket) {
 		return errInvalidBucket
+	}
+
+	if !isOwnerValid(config.OwnerFormatRegex, owner) {
+		return errInvalidOwner
 	}
 
 	return nil

--- a/store/inputValidation_test.go
+++ b/store/inputValidation_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ func TestIsIDValid(t *testing.T) {
 		ID       string
 		Expected bool
 	}
+	IDFormatRegex := regexp.MustCompile(IDFormatRegexSource)
 
 	tcs := []test{
 		{Name: "CharacterOver", ID: "7e8c5f378b4addbaebc70897c4478cca06009e3e360208ebd073dbee4b3774e7a", Expected: false},
@@ -23,7 +25,7 @@ func TestIsIDValid(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
 			assert := assert.New(t)
-			assert.Equal(tc.Expected, isIDValid(tc.ID))
+			assert.Equal(tc.Expected, isIDValid(IDFormatRegex, tc.ID))
 		})
 	}
 }
@@ -34,6 +36,8 @@ func TestIsBucketValid(t *testing.T) {
 		Bucket      string
 		Succeeds    bool
 	}
+
+	BucketFormatRegex := regexp.MustCompile(BucketFormatRegexSource)
 
 	tcs := []testCase{
 		{
@@ -61,7 +65,7 @@ func TestIsBucketValid(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.Description, func(t *testing.T) {
 			assert := assert.New(t)
-			assert.Equal(tc.Succeeds, isBucketValid(tc.Bucket))
+			assert.Equal(tc.Succeeds, isBucketValid(BucketFormatRegex, tc.Bucket))
 		})
 	}
 }

--- a/store/inputValidation_test.go
+++ b/store/inputValidation_test.go
@@ -30,7 +30,7 @@ func TestIsIDValid(t *testing.T) {
 	}
 }
 
-func TestIsBucketValid(t *testing.T) {
+func TestIsBucketValidFromDefaultSource(t *testing.T) {
 	type testCase struct {
 		Description string
 		Bucket      string
@@ -66,6 +66,43 @@ func TestIsBucketValid(t *testing.T) {
 		t.Run(tc.Description, func(t *testing.T) {
 			assert := assert.New(t)
 			assert.Equal(tc.Succeeds, isBucketValid(BucketFormatRegex, tc.Bucket))
+		})
+	}
+}
+
+func TestIsOwnerValidFromDefaultSource(t *testing.T) {
+	type testCase struct {
+		Description string
+		Owner       string
+		Succeeds    bool
+	}
+
+	OwnerFormatRegex := regexp.MustCompile(OwnerFormatRegexSource)
+
+	tcs := []testCase{
+		{
+			Description: "Too short",
+			Owner:       "xmidt",
+		},
+		{
+			Description: "Too long",
+			Owner:       "neque-porro-quisquam-est-qui-dolorem-ipsum-quia-dolor-sit-amet-c",
+		},
+		{
+			Description: "Owner is optional",
+			Owner:       "",
+			Succeeds:    true,
+		},
+		{
+			Description: "Success",
+			Owner:       "a-nice-readable-owner-indeed",
+			Succeeds:    true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Description, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(tc.Succeeds, isOwnerValid(OwnerFormatRegex, tc.Owner))
 		})
 	}
 }

--- a/store/transport_test.go
+++ b/store/transport_test.go
@@ -47,6 +47,15 @@ func TestGetOrDeleteItemRequestDecoder(t *testing.T) {
 			ExpectedErr: errInvalidBucket,
 		},
 		{
+			Name: "Invalid Owner",
+			URLVars: map[string]string{
+				"bucket": "california",
+				"id":     sfID,
+			},
+			Owner:       "shortName",
+			ExpectedErr: errInvalidOwner,
+		},
+		{
 			Name: "Happy path. No owner. Normal mode",
 			URLVars: map[string]string{
 				"bucket": "california",
@@ -79,7 +88,7 @@ func TestGetOrDeleteItemRequestDecoder(t *testing.T) {
 				"id":     sfID,
 			},
 
-			Owner:          "SF Giants",
+			Owner:          "SFGiantsTeam",
 			ElevatedAccess: true,
 
 			ExpectedDecodedRequest: &getOrDeleteItemRequest{
@@ -87,7 +96,7 @@ func TestGetOrDeleteItemRequestDecoder(t *testing.T) {
 					Bucket: "california",
 					ID:     sfID,
 				},
-				owner:     "SF Giants",
+				owner:     "SFGiantsTeam",
 				adminMode: true,
 			},
 		},
@@ -129,7 +138,7 @@ func TestEncodeGetOrDeleteItemResponse(t *testing.T) {
 		{
 			Name: "Happy path",
 			ItemResponse: &OwnableItem{
-				Owner: "xmidt",
+				Owner: "xmidtUSATeam",
 				Item: model.Item{
 					ID:  "NaYFGE961cS_3dpzJcoP3QTL4kBYcw9ua3Q6Hy5E4nI",
 					TTL: aws.Int64(20),
@@ -153,7 +162,7 @@ func TestEncodeGetOrDeleteItemResponse(t *testing.T) {
 			err := encodeGetOrDeleteItemResponse(context.Background(), recorder, testCase.ItemResponse)
 			assert.Equal(testCase.ExpectedErr, err)
 			assert.Equal(testCase.ExpectedBody, recorder.Body.String())
-			assert.Equal(testCase.ExpectedHeaders, recorder.HeaderMap)
+			assert.Equal(testCase.ExpectedHeaders, recorder.Header())
 			assert.Equal(testCase.ExpectedCode, recorder.Code)
 		})
 	}
@@ -190,10 +199,10 @@ func TestGetAllItemsRequestDecoder(t *testing.T) {
 				"bucket": "california",
 				"ID":     Sha256HexDigest("san francisco"),
 			},
-			Owner: "SF Giants",
+			Owner: "SFGiantsTeam",
 			ExpectedDecodedRequest: &getAllItemsRequest{
 				bucket:    "california",
-				owner:     "SF Giants",
+				owner:     "SFGiantsTeam",
 				adminMode: true,
 			},
 			ElevatedAccess: true,
@@ -273,7 +282,7 @@ func TestSetItemRequestDecoder(t *testing.T) {
 		{
 			Name:        "Capped TTL",
 			URLVars:     map[string]string{bucketVarKey: "variables", idVarKey: "4b13653e5d6d611de5999ab0e7c0aa67e1d83d4cba8349a04da0a431fb27f74b"},
-			Owner:       "math",
+			Owner:       "mathematics",
 			RequestBody: `{"id":"4b13653e5d6d611de5999ab0e7c0aa67e1d83d4cba8349a04da0a431fb27f74b", "data": {"x": 0, "y": 1, "z": 2}, "ttl": 90000}`,
 			ExpectedRequest: &setItemRequest{
 				item: OwnableItem{
@@ -282,7 +291,7 @@ func TestSetItemRequestDecoder(t *testing.T) {
 						Data: map[string]interface{}{"x": float64(0), "y": float64(1), "z": float64(2)},
 						TTL:  aws.Int64(int64((time.Hour * 24).Seconds())),
 					},
-					Owner: "math",
+					Owner: "mathematics",
 				},
 				key: model.Key{
 					Bucket: "variables",
@@ -294,7 +303,7 @@ func TestSetItemRequestDecoder(t *testing.T) {
 		{
 			Name:        "TTL Not Provided",
 			URLVars:     map[string]string{bucketVarKey: "variables", idVarKey: "4b13653e5d6d611de5999ab0e7c0aa67e1d83d4cba8349a04da0a431fb27f74b"},
-			Owner:       "math",
+			Owner:       "mathematics",
 			RequestBody: `{"id":"4b13653e5d6d611de5999ab0e7c0aa67e1d83d4cba8349a04da0a431fb27f74b", "data": {"x": 0, "y": 1, "z": 2}}`,
 			ExpectedRequest: &setItemRequest{
 				item: OwnableItem{
@@ -305,7 +314,7 @@ func TestSetItemRequestDecoder(t *testing.T) {
 						},
 						TTL: aws.Int64(int64((time.Hour * 24).Seconds())),
 					},
-					Owner: "math",
+					Owner: "mathematics",
 				},
 				key: model.Key{
 					Bucket: "variables",
@@ -331,6 +340,12 @@ func TestSetItemRequestDecoder(t *testing.T) {
 			ExpectedErr: errInvalidBucket,
 		},
 		{
+			Name:        "Invalid Owner",
+			URLVars:     map[string]string{bucketVarKey: "variables", idVarKey: "4b13653e5d6d611de5999ab0e7c0aa67e1d83d4cba8349a04da0a431fb27f74b"},
+			Owner:       "tooShort",
+			ExpectedErr: errInvalidOwner,
+		},
+		{
 			Name:        "ID mismatch",
 			URLVars:     map[string]string{bucketVarKey: "variables", idVarKey: "4b13653e5d6d611de5999ab0e7c0aa67e1d83d4cba8349a04da0a431fb27f74b"},
 			RequestBody: `{"id":"4b13653e5d6d611de5999ab0e7c0aa67e1d83d4cba8349a04da0a431fb27f74a", "data": {"x": 0, "y": 1, "z": 2}, "ttl": 3900}`,
@@ -339,7 +354,7 @@ func TestSetItemRequestDecoder(t *testing.T) {
 		{
 			Name:           "Happy Path. Admin mode",
 			URLVars:        map[string]string{bucketVarKey: "variables", idVarKey: "4b13653e5d6d611de5999ab0e7c0aa67e1d83d4cba8349a04da0a431fb27f74b"},
-			Owner:          "math",
+			Owner:          "mathematics",
 			ElevatedAccess: true,
 			RequestBody:    `{"id":"4b13653e5d6d611de5999ab0e7c0aa67e1d83d4cba8349a04da0a431fb27f74b", "data": {"x": 0, "y": 1, "z": 2}, "ttl": 39}`,
 			ExpectedRequest: &setItemRequest{
@@ -351,7 +366,7 @@ func TestSetItemRequestDecoder(t *testing.T) {
 						},
 						TTL: aws.Int64(39),
 					},
-					Owner: "math",
+					Owner: "mathematics",
 				},
 				key: model.Key{
 					Bucket: "variables",
@@ -363,7 +378,7 @@ func TestSetItemRequestDecoder(t *testing.T) {
 		{
 			Name:        "Alternative ID format",
 			URLVars:     map[string]string{bucketVarKey: "variables", idVarKey: "4B13653E5D6D611DE5999AB0E7C0AA67E1D83D4CBA8349A04DA0A431FB27F74B"},
-			Owner:       "math",
+			Owner:       "mathematics",
 			RequestBody: `{"id":"4b13653e5d6d611de5999ab0e7c0aa67e1d83d4cba8349a04da0a431fb27f74b", "data": {"x": 0, "y": 1, "z": 2}, "ttl": 39}`,
 			ExpectedRequest: &setItemRequest{
 				item: OwnableItem{
@@ -372,7 +387,7 @@ func TestSetItemRequestDecoder(t *testing.T) {
 						Data: map[string]interface{}{"x": float64(0), "y": float64(1), "z": float64(2)},
 						TTL:  aws.Int64(39),
 					},
-					Owner: "math",
+					Owner: "mathematics",
 				},
 				key: model.Key{
 					Bucket: "variables",


### PR DESCRIPTION
In addition to adding owner validation, I made the compiled regular expressions part of the transport config instead of package globals.