### PR TITLE
Update owner validation value in sample config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Update store section in sample config files. [#200](https://github.com/xmidt-org/argus/pull/200)
+- Update sample config value so argus webhook integration works out of the box in test environments. [#203](https://github.com/xmidt-org/argus/pull/203)
 
 ## [v0.5.1]
 - Fix github actions config for uploading test and coverage reports for sonarcloud. [#192](https://github.com/xmidt-org/argus/pull/192)

--- a/argus.yaml
+++ b/argus.yaml
@@ -125,7 +125,7 @@ userInputValidation:
 
   # ownerFormatRegex helps define the validity of a bucket through a regular expression.
   # (Optional) default: ^.{10,60}$
-  ownerFormatRegex: "^.{10,60}$"
+  ownerFormatRegex: "^.{4,60}$"
 
   # itemDataMaxDepth is the max allowed depth of the Item JSON data field.
   # If your DB supports up to N nested objects, itemDataMaxDepth should be set to 

--- a/deploy/packaging/argus_spruce.yaml
+++ b/deploy/packaging/argus_spruce.yaml
@@ -147,7 +147,7 @@ userInputValidation:
 
   # ownerFormatRegex helps define the validity of a bucket through a regular expression.
   # (Optional) default: ^.{10,60}$
-  ownerFormatRegex: (( grab $OWNER_FORMAT_REGEX || "^.{10,60}$" ))
+  ownerFormatRegex: (( grab $OWNER_FORMAT_REGEX || "^.{4,60}$" ))
 
   # itemDataMaxDepth is the max allowed depth of the Item JSON data field.
   # If your DB supports up to N nested objects, itemDataMaxDepth should be set to 


### PR DESCRIPTION
While attempting to create a webhook on Tr1d1um (using Argus), some community members saw that the request being made to Argus was being rejected as the length of the item's owner (in this case `user` fetched from the basic auth key used https://github.com/xmidt-org/tr1d1um/blob/a9260a04720397a2bd815bd40b6ea4bb9c1a360c/deploy/packaging/tr1d1um_spruce.yaml#L209) was less than the required minimum 6. 

To allow these kinds of requests to work out of the box, I'm proposing to update the config value to allow owners with length >=4.

Issue where this was reported: https://github.com/xmidt-org/tr1d1um/issues/227
