### PR TITLE
Remove Deprecated `webpa-common` Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]        
-- Update dependencies containing deprecated webpa-common
-- Fix linter
+## [Unreleased]
+
+## [v0.9.2]   
+- Update dependencies containing deprecated webpa-common #280 
+- Fix Linter #294 
 
 ## [v0.9.1]
 - Dependency update, note vulnerabilities
@@ -208,7 +210,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [v0.1.0] Tue May 07 2020 Jack Murdock - 0.1.0
 - initial creation
 
-[Unreleased]: https://github.com/xmidt-org/argus/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/xmidt-org/argus/compare/v0.9.2...HEAD
+[v0.9.1]: https://github.com/xmidt-org/argus/compare/v0.9.1...v0.9.2
 [v0.9.1]: https://github.com/xmidt-org/argus/compare/v0.9.0...v0.9.1
 [v0.9.0]: https://github.com/xmidt-org/argus/compare/v0.8.0...v0.9.0
 [v0.8.0]: https://github.com/xmidt-org/argus/compare/v0.7.0...v0.8.0


### PR DESCRIPTION
What's included:
- Update dependencies containing deprecated webpa-common #280 
- Fix Linter #294 

