### PR TITLE
Add iam based access for dynamodb

### DIFF
--- a/argus.yaml
+++ b/argus.yaml
@@ -77,8 +77,8 @@ store:
     # secretKey is the AWS secretKey to go with the accessKey to access dynamodb.
     secretKey: "secretKey"
 
-    # If iamBasedAccessEnabled is enabled, accessKey and secretKey will be fetched using IAM temporary credentials
-    iamBasedAccessEnabled: false
+    # If roleBasedAccess is enabled, accessKey and secretKey will be fetched using IAM temporary credentials
+    roleBasedAccess: true
 
   #yugabyte:
   #  # hosts is and array of address and port used to connect to the cluster.

--- a/argus.yaml
+++ b/argus.yaml
@@ -77,6 +77,9 @@ store:
     # secretKey is the AWS secretKey to go with the accessKey to access dynamodb.
     secretKey: "secretKey"
 
+    # If iamBasedAccessEnabled is enabled, accessKey and secretKey will be fetched using IAM temporary credentials
+    iamBasedAccessEnabled: false
+
   #yugabyte:
   #  # hosts is and array of address and port used to connect to the cluster.
   #  hosts:

--- a/argus.yaml
+++ b/argus.yaml
@@ -78,7 +78,7 @@ store:
     secretKey: "secretKey"
 
     # If roleBasedAccess is enabled, accessKey and secretKey will be fetched using IAM temporary credentials
-    roleBasedAccess: true
+    roleBasedAccess: false
 
   #yugabyte:
   #  # hosts is and array of address and port used to connect to the cluster.

--- a/store/dynamodb/db.go
+++ b/store/dynamodb/db.go
@@ -73,8 +73,8 @@ type Config struct {
 	// (Optional) Defaults to False.
 	DisableDualStack bool
 
-	// If iamBasedAccessEnabled is enabled, accessKey and secretKey will be fetched using IAM temporary credentials
-	IamBasedAccessEnabled bool
+	// If roleBasedAccess is enabled, accessKey and secretKey will be fetched using IAM temporary credentials
+	RoleBasedAccess bool
 }
 
 // dao adapts the underlying dynamodb data service to match
@@ -95,8 +95,8 @@ func NewDynamoDB(config Config, measures metric.Measures) (store.S, error) {
 		return nil, err
 	}
 
-	if config.IamBasedAccessEnabled {
-		awsRegion, err := getAwsRegionForCassandra(config)
+	if config.RoleBasedAccess {
+		awsRegion, err := getAwsRegionForRoleBasedAccess(config)
 		if err != nil {
 			return nil, err
 		}
@@ -139,7 +139,7 @@ func NewDynamoDB(config Config, measures metric.Measures) (store.S, error) {
 	}, nil
 }
 
-func getAwsRegionForCassandra(config Config) (string, error) {
+func getAwsRegionForRoleBasedAccess(config Config) (string, error) {
 	awsRegion := config.Region
 
 	if len(awsRegion) == 0 {


### PR DESCRIPTION
This pull request introduces IAM-based access for DynamoDB functionality. The AWS SDK will now automatically retrieve the secret access key and access key ID from the appropriate chain provider based on the specified AWS region. This retrieval is for the assumed role attached to the service's instance.

cc: @Sachin4403 