### PR TITLE
Add role based access support in dynamo db

### DIFF
--- a/argus.yaml
+++ b/argus.yaml
@@ -77,6 +77,9 @@ store:
     # secretKey is the AWS secretKey to go with the accessKey to access dynamodb.
     secretKey: "secretKey"
 
+    # If roleBasedAccess is enabled, accessKey and secretKey will be fetched using IAM temporary credentials
+    roleBasedAccess: false
+
   #yugabyte:
   #  # hosts is and array of address and port used to connect to the cluster.
   #  hosts:

--- a/store/dynamodb/db.go
+++ b/store/dynamodb/db.go
@@ -4,12 +4,15 @@ package dynamodb
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-playground/validator/v10"
 	"github.com/xmidt-org/argus/model"
 	"github.com/xmidt-org/argus/store"
@@ -69,6 +72,9 @@ type Config struct {
 	// dual stack (IPv4 and IPv6).
 	// (Optional) Defaults to False.
 	DisableDualStack bool
+
+	// If roleBasedAccess is enabled, accessKey and secretKey will be fetched using IAM temporary credentials
+	RoleBasedAccess bool
 }
 
 // dao adapts the underlying dynamodb data service to match
@@ -89,16 +95,44 @@ func NewDynamoDB(config Config, measures metric.Measures) (store.S, error) {
 		return nil, err
 	}
 
+	var creds credentials.Value
+	if config.RoleBasedAccess {
+		awsRegion, err := getAwsRegionForRoleBasedAccess(config)
+		if err != nil {
+			return nil, err
+		}
+
+		sess, err := session.NewSession(&aws.Config{
+			Region: aws.String(awsRegion)},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		value, err := sess.Config.Credentials.Get()
+		if err != nil {
+			return nil, err
+		}
+
+		creds = credentials.Value{
+			AccessKeyID:     value.AccessKeyID,
+			SecretAccessKey: value.SecretAccessKey,
+			SessionToken:    value.SessionToken,
+		}
+	} else {
+		creds = credentials.Value{
+			AccessKeyID:     config.AccessKey,
+			SecretAccessKey: config.SecretKey,
+		}
+	}
+
 	awsConfig := *aws.NewConfig().
 		WithEndpoint(config.Endpoint).
 		WithUseDualStack(!config.DisableDualStack).
 		WithMaxRetries(config.MaxRetries).
 		WithCredentialsChainVerboseErrors(true).
 		WithRegion(config.Region).
-		WithCredentials(credentials.NewStaticCredentialsFromCreds(credentials.Value{
-			AccessKeyID:     config.AccessKey,
-			SecretAccessKey: config.SecretKey,
-		}))
+		WithCredentials(credentials.NewStaticCredentialsFromCreds(creds))
 
 	svc, err := newService(awsConfig, "", config.Table, int64(config.GetAllLimit), &measures)
 	if err != nil {
@@ -109,6 +143,20 @@ func NewDynamoDB(config Config, measures metric.Measures) (store.S, error) {
 	return &dao{
 		s: svc,
 	}, nil
+}
+
+func getAwsRegionForRoleBasedAccess(config Config) (string, error) {
+	awsRegion := config.Region
+
+	if len(awsRegion) == 0 {
+		awsRegion = os.Getenv("AWS_REGION")
+	}
+
+	if len(awsRegion) == 0 {
+		return "", fmt.Errorf("%s", "Aws region is not provided")
+	}
+
+	return awsRegion, nil
 }
 
 func (d dao) Push(key model.Key, item store.OwnableItem) error {


### PR DESCRIPTION
This pull request introduces IAM-based access for DynamoDB functionality. The AWS SDK will now automatically retrieve the secret access key, access key ID and session token from the appropriate chain provider based on the specified AWS region. This retrieval is for the assumed role attached to the service's instance.