### PR TITLE
`db.go`: Rename "rolebasedaccess" to "usedefaultcredentialchain" to describe actual behavior

### DIFF
--- a/argus.yaml
+++ b/argus.yaml
@@ -78,8 +78,13 @@ store:
     # secretKey is the AWS secretKey to go with the accessKey to access dynamodb.
     secretKey: "secretKey"
 
-    # If roleBasedAccess is enabled, accessKey and secretKey will be fetched using IAM temporary credentials
-    roleBasedAccess: false
+    # Replaces "roleBasedAccess": If enabled, relies on (in order of precedence):
+    # 1. environment variables (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)":"
+    # 2. IAM attached to ECS task
+    # 3. IAM role attached to EC2 instance
+    # https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
+    useDefaultCredentialChain: false
+
 
   #yugabyte:
   #  # hosts is and array of address and port used to connect to the cluster.

--- a/store/dynamodb/db.go
+++ b/store/dynamodb/db.go
@@ -75,6 +75,9 @@ type Config struct {
 
 	// If roleBasedAccess is enabled, accessKey and secretKey will be fetched using IAM temporary credentials
 	RoleBasedAccess bool
+
+	// Mechanically identical to RoleBasedAccess, but with descriptive name
+	UseDefaultCredentialChain bool
 }
 
 // dao adapts the underlying dynamodb data service to match
@@ -97,7 +100,7 @@ func NewDynamoDB(config Config, measures metric.Measures) (store.S, error) {
 
 	var creds credentials.Value
 	var awsConfig aws.Config
-	if config.RoleBasedAccess {
+	if config.RoleBasedAccess || config.UseDefaultCredentialChain {
 		awsRegion, err := getAwsRegionForRoleBasedAccess(config)
 		if err != nil {
 			return nil, err

--- a/store/dynamodb/db.go
+++ b/store/dynamodb/db.go
@@ -63,10 +63,10 @@ type Config struct {
 	GetAllLimit int
 
 	// AccessKey is the AWS AccessKey credential.
-	AccessKey string
+	AccessKey *string
 
 	// SecretKey is the AWS SecretKey credential.
-	SecretKey string
+	SecretKey *string
 
 	// DisableDualStack indicates whether the connection to the DB should be
 	// dual stack (IPv4 and IPv6).
@@ -121,9 +121,12 @@ func NewDynamoDB(config Config, measures metric.Measures) (store.S, error) {
 			WithRegion(config.Region).
 			WithCredentials(sess.Config.Credentials)
 	} else {
+		if config.AccessKey == nil || config.SecretKey == nil {
+			return nil, fmt.Errorf("accessKey and secretKey must be provided when roleBasedAccess is false")
+		}
 		creds = credentials.Value{
-			AccessKeyID:     config.AccessKey,
-			SecretAccessKey: config.SecretKey,
+			AccessKeyID:     *config.AccessKey,
+			SecretAccessKey: *config.SecretKey,
 		}
 
 		awsConfig = *aws.NewConfig().


### PR DESCRIPTION
After reading through the SDK's behavior, the "roleBasedAccess" flag in fact uses the default credential chain for the `golang` AWS SDK. This updates the config value to match the behavior this has has the whole time.

