### PR TITLE
fix entrypoint.sh

### DIFF
--- a/.release/docker/entrypoint.sh
+++ b/.release/docker/entrypoint.sh
@@ -1,6 +1,7 @@
+#!/usr/bin/env sh
 ## SPDX-FileCopyrightText: 2021 Comcast Cable Communications Management, LLC
 ## SPDX-License-Identifier: Apache-2.0
-#!/usr/bin/env sh
+
 set -e
 
 # check arguments for an option that would cause /argus to stop


### PR DESCRIPTION
shell directive has to be the first line in the file or the docker image startup will break