### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   ci:
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
-      release-type:          library
+      release-type:          program
       release-arch-amd64:    true
       release-arch-arm64:    true
       release-docker:        true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   ci:
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
-      release-type:          program
+      release-type:          library
       release-arch-amd64:    true
       release-arch-arm64:    true
       release-docker:        true

--- a/.github/workflows/dependabot-approver.yml
+++ b/.github/workflows/dependabot-approver.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+    uses: xmidt-org/shared-go/.github/workflows/dependabot-approver.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,9 +11,12 @@ on:
     types:
       - opened
 
-permissions: {}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    uses: xmidt-org/shared-go/.github/workflows/proj-xmidt-team.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit


### PR DESCRIPTION
## Summary

This PR normalizes the CI/CD workflows to match the xmidt-org Ideal State:

- **ci.yml**: Changed `release-type` from `program` to `library` 
- **auto-release.yml**: Added top-level `permissions` block with `contents: write`
- **dependabot-approver.yml**: Updated to reference `xmidt-org/shared-go/.github/workflows/dependabot-approver.yml` and pinned to SHA `aff0471aa7e2f96ddb059beb178f63747a7cc57e` (v4.9.41)
- **proj-xmidt-team.yml**: Updated to reference `xmidt-org/shared-go/.github/workflows/proj-xmidt-team.yml`, pinned to SHA `aff0471aa7e2f96ddb059beb178f63747a7cc57e` (v4.9.41), and added required permissions (`contents: read`, `issues: write`, `pull-requests: write`)

Resolves #1089